### PR TITLE
Fix to support queries with >~2000 characters

### DIFF
--- a/uhelpers/archive_helpers.py
+++ b/uhelpers/archive_helpers.py
@@ -298,7 +298,7 @@ def execute_casjobs_query(userid, password, query, table_name, out_file,
         print(query)
 
     #         see https://galex.stsci.edu/casjobs/download/casjobs.config.x
-    jobs = casjobs.CasJobs(userid=userid, password=password,
+    jobs = casjobs.CasJobs(userid=userid, password=password, request_type="POST",
                            base_url=CASJOBS_BASE_URL)
 
     # get information on all previous jobs


### PR DESCRIPTION
In an effort to add isolation constraints for the guide stars in the target selection tool, the CasJobs queries has grown beyond the limit (which is said to be "about 2000 characters"). This PR addresses this issues by specifying the `request_type` argument to the CasJobs class.

Testing shows that queries that are shorter than the ~2000 characters should not be impacted the addition of this argument, meaning this fix seems to be back-compatible. 